### PR TITLE
Define fixed origin and clean up

### DIFF
--- a/gps_common/CMakeLists.txt
+++ b/gps_common/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(gps_common CXX)
 
+find_package(Eigen3 REQUIRED)
+
 ############
 ## Catkin ##
 ############
@@ -48,7 +50,7 @@ catkin_package(INCLUDE_DIRS include
 ## Build ##
 ###########
 add_compile_options(-std=c++11)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${catkin_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIR})
 add_executable(${PROJECT_NAME}/utm_odometry_node src/utm_odometry_node.cpp)
 set_target_properties(${PROJECT_NAME}/utm_odometry_node PROPERTIES OUTPUT_NAME "utm_odometry_node")
 target_link_libraries(${PROJECT_NAME}/utm_odometry_node ${catkin_LIBRARIES})

--- a/gps_common/launch/ins_translator.launch
+++ b/gps_common/launch/ins_translator.launch
@@ -1,17 +1,16 @@
 <launch>
-  
+
+   <arg name="frame_id" default="odom" />
+   <arg name="child_frame_id" default="base_link" />
+   <arg name="publish_odom_tf" default="true" />
+   <arg name="world_frame_id" default="world" />
+
    <node name="utm_odometry_node" pkg="gps_common" type="utm_odometry_node">
-   
-   <param name="frame_id" value="odom"/> 
-   <param name="child_frame_id" value="base_link"/>
-   <param name="use_ins" value="true"/>
-   <param name="publish_odom_tf" value="true"/>
-   <param name="broadcast_world_tf" value="true"/>
-
-   <param name="world_frame_id" value="world" /> 
-   <param name="world_child_frame_id" value="map"/>
-
-   
+       <param name="frame_id" value="$(arg frame_id)"/>
+       <param name="child_frame_id" value="$(arg child_frame_id)"/>
+       <param name="publish_odom_tf" value="$(arg publish_odom_tf)"/>
+       <param name="world_frame_id" value="$(arg world_frame_id)"/>
+       <param name="use_fixed_origin" value="false"/>
    </node>
 
 </launch>

--- a/gps_common/package.xml
+++ b/gps_common/package.xml
@@ -21,6 +21,8 @@
   <build_depend>novatel_gps_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
 
   <run_depend>message_filters</run_depend>
   <run_depend>message_runtime</run_depend>

--- a/gps_common/src/utm_odometry_node.cpp
+++ b/gps_common/src/utm_odometry_node.cpp
@@ -1,5 +1,5 @@
 /*
- * Translates sensor_msgs/NavSat{Fix,Status} into nav_msgs/Odometry using UTM
+ * Translates novatel_gps_msgs/Inspva into nav_msgs/Odometry using UTM
  */
 
 #include <ros/ros.h>
@@ -11,166 +11,194 @@
 #include <math.h>
 #include <Eigen/Dense>
 
+#define DEG2RAD M_PI / 180.0
+
 using namespace gps_common;
-
-static double radians_to_degrees = 180.0 / M_PI;
-static double degrees_to_radians = M_PI / 180.0;
-
-ros::Publisher odom_pub, world_odom_pub, origin_pub;
-ros::Subscriber gps_source_sub;
-std::string frame_id, child_frame_id, world_frame_id;
-bool use_fixed_origin, publish_odom_tf, ignore_z;
-
 using Rigid3d = std::pair<Eigen::Vector3d, Eigen::Quaterniond>;
-Rigid3d world_to_local_frame;
 
-void insCallBack(const novatel_gps_msgs::InspvaConstPtr& ins) {
+class UTMOdometryNode {
+  private:
+    ros::NodeHandle node;
+    ros::NodeHandle priv_node;
 
-  static tf::TransformBroadcaster odom_tf_broadcaster;
+    std::string frame_id, child_frame_id, world_frame_id;
+    bool publish_odom_tf, ignore_z;
+    Rigid3d world_to_local_frame;
 
-  static geometry_msgs::TransformStamped odom_tf, world_tf;
-  static geometry_msgs::PoseStamped imu_pose;
+    ros::Publisher odom_pub, world_odom_pub, origin_pub;
+    ros::Subscriber inspva_sub;
+    tf::TransformBroadcaster odom_tf_broadcaster;
+    geometry_msgs::TransformStamped odom_tf;
+    nav_msgs::Odometry odom;
+    nav_msgs::Odometry odom_world;
 
-  double northing, easting, z;
-  std::string zone;
-  LLtoUTM(ins->latitude, ins->longitude, northing, easting, zone);
-  if (ignore_z)
-    z = 0.0;
-  else
-    z = ins->height;
+    void InitOrigin() {
+      geometry_msgs::PoseStamped origin;
+      bool use_fixed_origin;
+      priv_node.param<bool>("use_fixed_origin", use_fixed_origin, false);
 
-  Eigen::Vector3d position(easting, northing, z);
-  Eigen::Matrix3d rot_mat = world_to_local_frame.second.toRotationMatrix();
-  Eigen::Vector3d local_position = rot_mat * position + world_to_local_frame.first;
-  if (ignore_z) 
-    local_position = Eigen::Vector3d(local_position(0), local_position(1), 0.0);
+      // if use_fixed_origin is false, wait for a /inspva message
+      // and use it as the origin
+      if (!use_fixed_origin) {
+        auto ins = ros::topic::waitForMessage<novatel_gps_msgs::Inspva>("/inspva", node);
+        double northing, easting;
+        std::string zone;
+        LLtoUTM(ins->latitude, ins->longitude, northing, easting, zone);
+        origin.pose.position.x = easting;
+        origin.pose.position.y = northing;
+        origin.pose.position.z = ins->height;
+        origin.pose.orientation = tf::createQuaternionMsgFromRollPitchYaw(
+          ins->roll * DEG2RAD,
+          ins->pitch * DEG2RAD,
+          (90.0 - ins->azimuth) * DEG2RAD);
+      } else {
+        // TODO more than parameters, a service call would be better
+        // so that we could change the origin at runtime
+        priv_node.param<double>("origin_x", origin.pose.position.x, 0);
+        priv_node.param<double>("origin_y", origin.pose.position.y, 0);
+        priv_node.param<double>("origin_z", origin.pose.position.z, 0);
+        // TODO using euler angles might be easier
+        priv_node.param<double>("origin_ox", origin.pose.orientation.x, 0);
+        priv_node.param<double>("origin_oy", origin.pose.orientation.y, 0);
+        priv_node.param<double>("origin_oz", origin.pose.orientation.z, 0);
+        priv_node.param<double>("origin_ow", origin.pose.orientation.w, 1);
+      }
 
-  Eigen::Quaterniond orientation = Eigen::AngleAxisd(ins->roll * degrees_to_radians, Eigen::Vector3d::UnitX()) *
-                    Eigen::AngleAxisd(ins->pitch * degrees_to_radians, Eigen::Vector3d::UnitY()) *
-                    Eigen::AngleAxisd((90.0 - ins->azimuth) * degrees_to_radians, Eigen::Vector3d::UnitZ());
-  Eigen::Quaterniond local_orientation = world_to_local_frame.second * orientation;
+      if (ignore_z)
+        origin.pose.position.z = 0;
 
-  nav_msgs::Odometry odom;
-  odom.header.stamp = ins->header.stamp;
+      origin.header.frame_id = world_frame_id;
+      origin.header.stamp = ros::Time::now();
 
-  if (frame_id.empty())
-    odom.header.frame_id = ins->header.frame_id;
-  else
-    odom.header.frame_id = frame_id;
-  odom.child_frame_id = child_frame_id;
+      PublishOrigin(origin);
+    }
 
-  odom.pose.pose.position.x = local_position(0);
-  odom.pose.pose.position.y = local_position(1);
-  odom.pose.pose.position.z = local_position(2);
-  odom.pose.pose.orientation.w = local_orientation.w();
-  odom.pose.pose.orientation.x = local_orientation.x();
-  odom.pose.pose.orientation.y = local_orientation.y();
-  odom.pose.pose.orientation.z = local_orientation.z();
+    void PublishOrigin(const geometry_msgs::PoseStamped& origin) {
+      origin_pub = node.advertise<geometry_msgs::PoseStamped>("/origin", 1, true);
+      origin_pub.publish(origin);
 
-  double velocity = sqrt(pow(ins->east_velocity,2) + pow(ins->north_velocity,2) + pow(ins->up_velocity,2));
-  odom.twist.twist.linear.x = velocity;
-  odom.twist.twist.linear.y = 0; //TODO:
-  odom.twist.twist.linear.z = 0; //TODO:
+      const Eigen::Vector3d translation(origin.pose.position.x,
+        origin.pose.position.y,
+        origin.pose.position.z);
+      const Eigen::Quaterniond rotation(origin.pose.orientation.w,
+        origin.pose.orientation.x,
+        origin.pose.orientation.y,
+        origin.pose.orientation.z);
+        world_to_local_frame = std::make_pair(rotation * -translation, rotation);
+    }
 
-  // TODO use covariance from inscov
-  odom.pose.covariance = {1,0,0,0,0,0,
-            0,1,0,0,0,0,
-            0,0,1,0,0,0,
-            0,0,0,1,0,0,
-            0,0,0,0,1,0,
-            0,0,0,0,0,1};
-  odom_pub.publish(odom);
+    void PublishOdomTF(const nav_msgs::Odometry& odom) {
+      odom_tf.header.stamp = odom.header.stamp;
+      odom_tf.transform.translation.x = odom.pose.pose.position.x;
+      odom_tf.transform.translation.y = odom.pose.pose.position.y;
+      odom_tf.transform.translation.z = odom.pose.pose.position.z;
 
-  if (publish_odom_tf) {
-    odom_tf.header.stamp = odom.header.stamp;
-    odom_tf.header.frame_id = frame_id;
-    odom_tf.child_frame_id = child_frame_id;
-    odom_tf.transform.translation.x = odom.pose.pose.position.x;
-    odom_tf.transform.translation.y = odom.pose.pose.position.y;
-    odom_tf.transform.translation.z = odom.pose.pose.position.z;
+      odom_tf.transform.rotation.x = odom.pose.pose.orientation.x;
+      odom_tf.transform.rotation.y = odom.pose.pose.orientation.y;
+      odom_tf.transform.rotation.z = odom.pose.pose.orientation.z;
+      odom_tf.transform.rotation.w = odom.pose.pose.orientation.w;
 
-    odom_tf.transform.rotation.x = odom.pose.pose.orientation.x;
-    odom_tf.transform.rotation.y = odom.pose.pose.orientation.y;
-    odom_tf.transform.rotation.z = odom.pose.pose.orientation.z;
-    odom_tf.transform.rotation.w = odom.pose.pose.orientation.w;
+      odom_tf_broadcaster.sendTransform(odom_tf);
+    }
 
-    odom_tf_broadcaster.sendTransform(odom_tf);
-  }
+    void INSPVACallBack(const novatel_gps_msgs::InspvaConstPtr& ins) {
 
-  nav_msgs::Odometry odom_world;
-  // keep twist and covariance matrix
-  odom_world = odom;
-  // replace pose
-  odom_world.pose.pose.position.x = position(0);
-  odom_world.pose.pose.position.y = position(1);
-  odom_world.pose.pose.position.z = position(2);
-  odom_world.pose.pose.orientation.w = orientation.w();
-  odom_world.pose.pose.orientation.x = orientation.x();
-  odom_world.pose.pose.orientation.y = orientation.y();
-  odom_world.pose.pose.orientation.z = orientation.z();
-  world_odom_pub.publish(odom_world);
-}
+      double northing, easting, z;
+      std::string zone;
+      LLtoUTM(ins->latitude, ins->longitude, northing, easting, zone);
+      if (ignore_z)
+        z = 0.0;
+      else
+        z = ins->height;
 
-int main (int argc, char **argv) {
+      Eigen::Vector3d position(easting, northing, z);
+      Eigen::Matrix3d rot_mat = world_to_local_frame.second.toRotationMatrix();
+      Eigen::Vector3d local_position = rot_mat * position + world_to_local_frame.first;
+      if (ignore_z) 
+        local_position = Eigen::Vector3d(local_position(0), local_position(1), 0.0);
+
+      Eigen::Quaterniond orientation = Eigen::AngleAxisd(ins->roll * DEG2RAD, Eigen::Vector3d::UnitX()) *
+        Eigen::AngleAxisd(ins->pitch * DEG2RAD, Eigen::Vector3d::UnitY()) *
+        Eigen::AngleAxisd((90.0 - ins->azimuth) * DEG2RAD, Eigen::Vector3d::UnitZ());
+      Eigen::Quaterniond local_orientation = world_to_local_frame.second * orientation;
+
+      odom.header.stamp = ins->header.stamp;
+      odom.pose.pose.position.x = local_position(0);
+      odom.pose.pose.position.y = local_position(1);
+      odom.pose.pose.position.z = local_position(2);
+      odom.pose.pose.orientation.w = local_orientation.w();
+      odom.pose.pose.orientation.x = local_orientation.x();
+      odom.pose.pose.orientation.y = local_orientation.y();
+      odom.pose.pose.orientation.z = local_orientation.z();
+
+      double velocity = sqrt(pow(ins->east_velocity,2) + pow(ins->north_velocity,2) + pow(ins->up_velocity,2));
+      odom.twist.twist.linear.x = velocity;
+      odom.twist.twist.linear.y = 0; //TODO:
+      odom.twist.twist.linear.z = 0; //TODO:
+
+      // TODO use covariance from inscov
+      odom.pose.covariance = {1,0,0,0,0,0,
+                0,1,0,0,0,0,
+                0,0,1,0,0,0,
+                0,0,0,1,0,0,
+                0,0,0,0,1,0,
+                0,0,0,0,0,1};
+      odom_pub.publish(odom);
+
+      if (publish_odom_tf)
+        PublishOdomTF(odom);
+
+      // keep twist and covariance matrix
+      odom_world.pose = odom.pose;
+      odom_world.header.stamp = odom.header.stamp;
+      // replace timestamp, position and orientation
+      odom_world.pose.pose.position.x = position(0);
+      odom_world.pose.pose.position.y = position(1);
+      odom_world.pose.pose.position.z = position(2);
+      odom_world.pose.pose.orientation.w = orientation.w();
+      odom_world.pose.pose.orientation.x = orientation.x();
+      odom_world.pose.pose.orientation.y = orientation.y();
+      odom_world.pose.pose.orientation.z = orientation.z();
+      world_odom_pub.publish(odom_world);
+    }
+
+  public:
+    UTMOdometryNode() : priv_node("~") {}
+
+    void Run() {
+      priv_node.param<std::string>("frame_id", frame_id, std::string("odom"));
+      priv_node.param<std::string>("child_frame_id", child_frame_id, std::string("base_link"));
+      priv_node.param<std::string>("world_frame_id", world_frame_id, std::string("world"));
+      priv_node.param<bool>("publish_odom_tf", publish_odom_tf, false);
+      priv_node.param<bool>("ignore_z", ignore_z, false);
+
+      odom.header.frame_id = frame_id;
+      odom.child_frame_id = child_frame_id;
+      odom_tf.header = odom.header;
+      odom_tf.child_frame_id = odom.child_frame_id;
+      odom_world.header.frame_id = world_frame_id;
+
+      InitOrigin();
+
+      int pub_queue_size;
+      priv_node.param("pub_queue_size", pub_queue_size, 10);
+      if(pub_queue_size < 0)
+          pub_queue_size = 10;
+      odom_pub = node.advertise<nav_msgs::Odometry>("/odom", pub_queue_size);
+      world_odom_pub = node.advertise<nav_msgs::Odometry>("/odom_world", pub_queue_size);
+
+      int sub_queue_size;
+      priv_node.param("sub_queue_size", sub_queue_size, 10);
+      if(sub_queue_size < 0)
+        sub_queue_size = 10;
+      inspva_sub = node.subscribe("/inspva", sub_queue_size, &UTMOdometryNode::INSPVACallBack, this);
+      ros::spin();
+    }
+};
+
+int main(int argc, char** argv) {
   ros::init(argc, argv, "utm_odometry_node");
-  ros::NodeHandle node;
-  ros::NodeHandle priv_node("~");
-  priv_node.param<std::string>("frame_id", frame_id, "");
-  priv_node.param<std::string>("child_frame_id", child_frame_id, "");
-  priv_node.param<std::string>("world_frame_id", world_frame_id, "world");
-  priv_node.param<bool>("publish_odom_tf", publish_odom_tf, false);
-  priv_node.param<bool>("ignore_z", ignore_z, false);
-
-  // TODO more than parameters, a service call would be better
-  // so that we could change the origin at runtime
-  geometry_msgs::PoseStamped origin;
-  priv_node.param<bool>("use_fixed_origin", use_fixed_origin, false);
-  priv_node.param<double>("origin_x", origin.pose.position.x, 0);
-  priv_node.param<double>("origin_y", origin.pose.position.y, 0);
-  priv_node.param<double>("origin_z", origin.pose.position.z, 0);
-  // TODO using euler angles might be easier
-  priv_node.param<double>("origin_ox", origin.pose.orientation.x, 0);
-  priv_node.param<double>("origin_oy", origin.pose.orientation.y, 0);
-  priv_node.param<double>("origin_oz", origin.pose.orientation.z, 0);
-  priv_node.param<double>("origin_ow", origin.pose.orientation.w, 1);
-
-  // if use_fixed_origin is false, wait for a /inspva message
-  // and use it as the origin
-  if (!use_fixed_origin) {
-    auto ins = ros::topic::waitForMessage<novatel_gps_msgs::Inspva>("/inspva", node);
-    double northing, easting;
-    std::string zone;
-    LLtoUTM(ins->latitude, ins->longitude, northing, easting, zone);
-    origin.pose.position.x = easting;
-    origin.pose.position.y = northing;
-    origin.pose.position.z = ins->height;
-    origin.pose.orientation = tf::createQuaternionMsgFromRollPitchYaw(
-      ins->roll * degrees_to_radians,
-      ins->pitch * degrees_to_radians,
-       (90.0 - ins->azimuth) * degrees_to_radians);
-  }
-
-  if (ignore_z)
-    origin.pose.position.z = 0;
-
-  origin.header.frame_id = world_frame_id;
-  origin.header.stamp = ros::Time::now();
-  origin_pub = node.advertise<geometry_msgs::PoseStamped>("/origin", 1, true);
-  origin_pub.publish(origin);
-
-  const Eigen::Vector3d translation(origin.pose.position.x,
-    origin.pose.position.y,
-    origin.pose.position.z);
-  const Eigen::Quaterniond rotation(origin.pose.orientation.w,
-    origin.pose.orientation.x,
-    origin.pose.orientation.y,
-    origin.pose.orientation.z);
-  world_to_local_frame = std::make_pair(rotation * -translation, rotation);
-
-  odom_pub = node.advertise<nav_msgs::Odometry>("/odom", 10);
-  world_odom_pub = node.advertise<nav_msgs::Odometry>("/odom_world", 10);
-  gps_source_sub = node.subscribe("/inspva", 10, insCallBack);
-
-  ros::spin();
+  UTMOdometryNode node;
+  node.Run();
+  return 0;
 }
-

--- a/gps_common/src/utm_odometry_node.cpp
+++ b/gps_common/src/utm_odometry_node.cpp
@@ -3,244 +3,169 @@
  */
 
 #include <ros/ros.h>
-#include <message_filters/subscriber.h>
-#include <message_filters/time_synchronizer.h>
-#include <sensor_msgs/NavSatStatus.h>
-#include <sensor_msgs/NavSatFix.h>
 #include <gps_common/conversions.h>
 #include <nav_msgs/Odometry.h>
 #include <novatel_gps_msgs/Inspva.h>
-#include <geometry_msgs/TransformStamped.h>
-#include <geometry_msgs/QuaternionStamped.h>
 #include <tf/transform_broadcaster.h>
-#include <tf/transform_listener.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <math.h>
+#include <Eigen/Dense>
 
 using namespace gps_common;
 
-ros::Publisher odom_pub, world_odom_pub;
+static double radians_to_degrees = 180.0 / M_PI;
+static double degrees_to_radians = M_PI / 180.0;
+
+ros::Publisher odom_pub, world_odom_pub, origin_pub;
 ros::Subscriber gps_source_sub;
-std::string frame_id, child_frame_id, world_frame_id, world_child_frame_id;
-double rot_cov, y_offset, x_offset, z_offset;
-double roll_offset, pitch_offset, yaw_offset;
-bool odom_init, publish_odom_tf, broadcast_world_tf;
+std::string frame_id, child_frame_id, world_frame_id;
+bool use_fixed_origin, publish_odom_tf, ignore_z;
 
-
-void callback(const sensor_msgs::NavSatFixConstPtr& fix) {
-  if (fix->status.status == sensor_msgs::NavSatStatus::STATUS_NO_FIX) {
-    ROS_DEBUG_THROTTLE(60,"No fix.");
-    return;
-  }
-
-  if (fix->header.stamp == ros::Time(0)) {
-    return;
-  }
-
-  double northing, easting;
-  std::string zone;
-
-  LLtoUTM(fix->latitude, fix->longitude, northing, easting, zone);
-
-  if (odom_pub) {
-    nav_msgs::Odometry odom;
-    odom.header.stamp = fix->header.stamp;
-
-    if (frame_id.empty())
-      odom.header.frame_id = fix->header.frame_id;
-    else
-      odom.header.frame_id = frame_id;
-
-    odom.child_frame_id = child_frame_id;
-
-    odom.pose.pose.position.x = easting;
-    odom.pose.pose.position.y = northing;
-    odom.pose.pose.position.z = fix->altitude;
-    
-    odom.pose.pose.orientation.x = 0;
-    odom.pose.pose.orientation.y = 0;
-    odom.pose.pose.orientation.z = 0;
-    odom.pose.pose.orientation.w = 1;
-    
-    // Use ENU covariance to build XYZRPY covariance
-    boost::array<double, 36> covariance = {{
-      fix->position_covariance[0],
-      fix->position_covariance[1],
-      fix->position_covariance[2],
-      0, 0, 0,
-      fix->position_covariance[3],
-      fix->position_covariance[4],
-      fix->position_covariance[5],
-      0, 0, 0,
-      fix->position_covariance[6],
-      fix->position_covariance[7],
-      fix->position_covariance[8],
-      0, 0, 0,
-      0, 0, 0, rot_cov, 0, 0,
-      0, 0, 0, 0, rot_cov, 0,
-      0, 0, 0, 0, 0, rot_cov
-    }};
-
-    odom.pose.covariance = covariance;
-
-    odom_pub.publish(odom);
-  }
-}
+using Rigid3d = std::pair<Eigen::Vector3d, Eigen::Quaterniond>;
+Rigid3d world_to_local_frame;
 
 void insCallBack(const novatel_gps_msgs::InspvaConstPtr& ins) {
 
-  double northing, easting;
-  std::string zone;
   static tf::TransformBroadcaster odom_tf_broadcaster;
 
   static geometry_msgs::TransformStamped odom_tf, world_tf;
   static geometry_msgs::PoseStamped imu_pose;
 
-  tf::TransformListener tfListener;
+  double northing, easting, z;
+  std::string zone;
   LLtoUTM(ins->latitude, ins->longitude, northing, easting, zone);
-  if(!odom_init)
-  {
-	  x_offset = easting;
-	  y_offset = northing;
-	  z_offset = ins->height;
+  if (ignore_z) z = 0.0;
+  else z = ins->height;
 
-      roll_offset = ins->roll;
-      pitch_offset = ins->pitch;
-      yaw_offset = ins->azimuth;
-      odom_init = true;
+  Eigen::Vector3d position(easting, northing, z);
+  Eigen::Matrix3d rot_mat = world_to_local_frame.second.toRotationMatrix();
+  Eigen::Vector3d local_position = rot_mat * position + world_to_local_frame.first;
+  if (ignore_z) 
+    local_position = Eigen::Vector3d(local_position(0), local_position(1), 0.0);
+
+  Eigen::Quaterniond orientation = Eigen::AngleAxisd(ins->roll * degrees_to_radians, Eigen::Vector3d::UnitX()) *
+                    Eigen::AngleAxisd(ins->pitch * degrees_to_radians, Eigen::Vector3d::UnitY()) *
+                    Eigen::AngleAxisd((90.0 - ins->azimuth) * degrees_to_radians, Eigen::Vector3d::UnitZ());
+  Eigen::Quaterniond local_orientation = world_to_local_frame.second * orientation;
+
+  nav_msgs::Odometry odom;
+  odom.header.stamp = ins->header.stamp;
+
+  if (frame_id.empty())
+    odom.header.frame_id = ins->header.frame_id;
+  else
+    odom.header.frame_id = frame_id;
+  odom.child_frame_id = child_frame_id;
+
+  odom.pose.pose.position.x = local_position(0);
+  odom.pose.pose.position.y = local_position(1);
+  odom.pose.pose.position.z = local_position(2);
+  odom.pose.pose.orientation.w = local_orientation.w();
+  odom.pose.pose.orientation.x = local_orientation.x();
+  odom.pose.pose.orientation.y = local_orientation.y();
+  odom.pose.pose.orientation.z = local_orientation.z();
+
+  double velocity = sqrt(pow(ins->east_velocity,2) + pow(ins->north_velocity,2) + pow(ins->up_velocity,2));
+  odom.twist.twist.linear.x = velocity;
+  odom.twist.twist.linear.y = 0; //TODO:
+  odom.twist.twist.linear.z = 0; //TODO:
+
+  // TODO use covariance from inscov
+  odom.pose.covariance = {1,0,0,0,0,0,
+            0,1,0,0,0,0,
+            0,0,1,0,0,0,
+            0,0,0,1,0,0,
+            0,0,0,0,1,0,
+            0,0,0,0,0,1};
+  odom_pub.publish(odom);
+
+  if (publish_odom_tf) {
+    odom_tf.header.stamp = odom.header.stamp;
+    odom_tf.header.frame_id = frame_id;
+    odom_tf.child_frame_id = child_frame_id;
+    odom_tf.transform.translation.x = odom.pose.pose.position.x;
+    odom_tf.transform.translation.y = odom.pose.pose.position.y;
+    odom_tf.transform.translation.z = odom.pose.pose.position.z;
+
+    odom_tf.transform.rotation.x = odom.pose.pose.orientation.x;
+    odom_tf.transform.rotation.y = odom.pose.pose.orientation.y;
+    odom_tf.transform.rotation.z = odom.pose.pose.orientation.z;
+    odom_tf.transform.rotation.w = odom.pose.pose.orientation.w;
+
+    odom_tf_broadcaster.sendTransform(odom_tf);
   }
-  if (odom_pub) {
-    nav_msgs::Odometry odom;
-    nav_msgs::Odometry odom_world;
-    odom.header.stamp = ins->header.stamp;
 
-    if (frame_id.empty())
-      odom.header.frame_id = ins->header.frame_id;
-    else
-      odom.header.frame_id = frame_id;
-
-    odom.child_frame_id = child_frame_id;
-
-    odom.pose.pose.position.x = easting - x_offset;
-    odom.pose.pose.position.y = northing - y_offset;
-    odom.pose.pose.position.z = 0;
-
-    double yaw =   90 - ins->azimuth; //need to do this 90deg offset per novatel requirements.
-    double pitch = ins->pitch;
-    double roll =  ins->roll;
-
-    roll = roll * 0.01745329252;
-    pitch = pitch * 0.01745329252;
-    yaw = yaw * 0.01745329252; // pi/180 convert to radians
-
-    tf::Quaternion quat_imu;
-    quat_imu.setRPY(roll, pitch, yaw);
-
-    odom.pose.pose.orientation.x = quat_imu[0];
-    odom.pose.pose.orientation.y = quat_imu[1];
-    odom.pose.pose.orientation.z = quat_imu[2];
-    odom.pose.pose.orientation.w = quat_imu[3];
-
-
-    double velocity = sqrt(pow(ins->east_velocity,2)+pow(ins->north_velocity,2)+pow(ins->up_velocity,2));
-
-    odom.twist.twist.linear.x = velocity;
-    odom.twist.twist.linear.y = 0; //TODO:
-    odom.twist.twist.linear.z = 0; //TODO:
-
-    odom.pose.covariance = {1,0,0,0,0,0,
-			 	 	 	 	0,1,0,0,0,0,
-							0,0,1,0,0,0,
-							0,0,0,1,0,0,
-							0,0,0,0,1,0,
-							0,0,0,0,0,1};
-
-    odom_world = odom;
-    odom_world.pose.pose.position.x = easting;
-    odom_world.pose.pose.position.y = northing;
-    odom_world.pose.pose.position.z = ins->height;
-
-    world_odom_pub.publish(odom_world);
-    odom_pub.publish(odom);
-
-    if(publish_odom_tf)
-    {
-    	odom_tf.header.stamp = odom.header.stamp;
-        odom_tf.header.frame_id = frame_id;
-        odom_tf.child_frame_id = child_frame_id;
-        odom_tf.transform.translation.x = odom.pose.pose.position.x;
-        odom_tf.transform.translation.y = odom.pose.pose.position.y;
-        odom_tf.transform.translation.z = odom.pose.pose.position.z;
-
-        odom_tf.transform.rotation.x = quat_imu[0];
-        odom_tf.transform.rotation.y = quat_imu[1];
-        odom_tf.transform.rotation.z = quat_imu[2];
-        odom_tf.transform.rotation.w = quat_imu[3];
-
-    	odom_tf_broadcaster.sendTransform(odom_tf);
-    }
-    if(broadcast_world_tf)
-    {
-    	world_tf.header.stamp = odom.header.stamp; //static tf from initial world position.
-    	world_tf.header.frame_id = world_frame_id;
-    	world_tf.child_frame_id = world_child_frame_id;
-
-    	world_tf.transform.translation.x = x_offset;
-    	world_tf.transform.translation.y = y_offset;
-    	world_tf.transform.translation.z = 0;
-
-    	tf::Quaternion quat_world;
-    	quat_world.setRPY(roll_offset, pitch_offset, yaw_offset);
-
-    	world_tf.transform.rotation.x = quat_world[0];
-    	world_tf.transform.rotation.y = quat_world[1];
-    	world_tf.transform.rotation.z = quat_world[2];
-    	world_tf.transform.rotation.w = quat_world[3];
-
-    	odom_tf_broadcaster.sendTransform(world_tf);
-    }
-
-  }
+  nav_msgs::Odometry odom_world;
+  // keep twist and covariance matrix
+  odom_world = odom;
+  // replace pose
+  odom_world.pose.pose.position.x = position(0);
+  odom_world.pose.pose.position.y = position(1);
+  odom_world.pose.pose.position.z = position(2);
+  odom_world.pose.pose.orientation.w = orientation.w();
+  odom_world.pose.pose.orientation.x = orientation.x();
+  odom_world.pose.pose.orientation.y = orientation.y();
+  odom_world.pose.pose.orientation.z = orientation.z();
+  world_odom_pub.publish(odom_world);
 }
-
 
 int main (int argc, char **argv) {
   ros::init(argc, argv, "utm_odometry_node");
   ros::NodeHandle node;
   ros::NodeHandle priv_node("~");
-  bool use_ins = true;
-  odom_init = false; //initialization flag for odom.
-  publish_odom_tf = false;
-  broadcast_world_tf = false;
   priv_node.param<std::string>("frame_id", frame_id, "");
   priv_node.param<std::string>("child_frame_id", child_frame_id, "");
-  priv_node.param<double>("rot_covariance", rot_cov, 99999.0);
+  priv_node.param<std::string>("world_frame_id", world_frame_id, "world");
+  priv_node.param<bool>("publish_odom_tf", publish_odom_tf, false);
+  priv_node.param<bool>("ignore_z", ignore_z, false);
 
-  priv_node.param<std::string>("world_frame_id", world_frame_id, "");
-  priv_node.param<std::string>("world_child_frame_id", world_child_frame_id, "");
+  // more than parameters, a service call would be better
+  // so that we could change the origin at runtime
+  geometry_msgs::PoseStamped origin;
+  priv_node.param<bool>("use_fixed_origin", use_fixed_origin, false);
+  priv_node.param<double>("origin_x", origin.pose.position.x, 0);
+  priv_node.param<double>("origin_y", origin.pose.position.y, 0);
+  priv_node.param<double>("origin_z", origin.pose.position.z, 0);
+  // using euler angles might be easier
+  priv_node.param<double>("origin_ox", origin.pose.orientation.x, 0);
+  priv_node.param<double>("origin_oy", origin.pose.orientation.y, 0);
+  priv_node.param<double>("origin_oz", origin.pose.orientation.z, 0);
+  priv_node.param<double>("origin_ow", origin.pose.orientation.w, 1);
 
-
-  if(!priv_node.getParam("use_ins", use_ins))
-	  ROS_WARN_STREAM("No use_ins param provided, using default: "<<use_ins);
-
-  if(!priv_node.getParam("publish_odom_tf", publish_odom_tf))
-	  ROS_WARN_STREAM("No publish_odom_tf param provided, using default: "<<publish_odom_tf);
-
-  if(!priv_node.getParam("broadcast_world_tf",broadcast_world_tf))
-	  ROS_WARN_STREAM("No world_tf param provided, using default: "<<broadcast_world_tf);
-
-
-  if(use_ins)
-  {
-	  odom_pub = node.advertise<nav_msgs::Odometry>("/odom", 10);
-	  world_odom_pub = node.advertise<nav_msgs::Odometry>("/odom_world", 10);
-	  gps_source_sub = node.subscribe("/inspva", 10, insCallBack);
+  if (!use_fixed_origin) {
+    auto ins = ros::topic::waitForMessage<novatel_gps_msgs::Inspva>("/inspva", node);
+    double northing, easting;
+    std::string zone;
+    LLtoUTM(ins->latitude, ins->longitude, northing, easting, zone);
+    origin.pose.position.x = easting;
+    origin.pose.position.y = northing;
+    origin.pose.position.z = ins->height;
+    origin.pose.orientation = tf::createQuaternionMsgFromRollPitchYaw(
+      ins->roll * degrees_to_radians,
+      ins->pitch * degrees_to_radians,
+       (90.0 - ins->azimuth) * degrees_to_radians);
   }
-  else
-  {
-	  odom_pub = node.advertise<nav_msgs::Odometry>("odom", 10);
-	  gps_source_sub = node.subscribe("fix", 10, callback);
-  }
+
+  if (ignore_z)
+    origin.pose.position.z = 0;
+
+  origin.header.frame_id = world_frame_id;
+  origin.header.stamp = ros::Time::now();
+  origin_pub = node.advertise<geometry_msgs::PoseStamped>("/origin", 1, true);
+  origin_pub.publish(origin);
+
+  const Eigen::Vector3d translation(origin.pose.position.x,
+    origin.pose.position.y,
+    origin.pose.position.z);
+  const Eigen::Quaterniond rotation(origin.pose.orientation.w,
+    origin.pose.orientation.x,
+    origin.pose.orientation.y,
+    origin.pose.orientation.z);
+  world_to_local_frame = std::make_pair(rotation * -translation, rotation);
+
+  odom_pub = node.advertise<nav_msgs::Odometry>("/odom", 10);
+  world_odom_pub = node.advertise<nav_msgs::Odometry>("/odom_world", 10);
+  gps_source_sub = node.subscribe("/inspva", 10, insCallBack);
 
   ros::spin();
 }

--- a/gps_common/src/utm_odometry_node.cpp
+++ b/gps_common/src/utm_odometry_node.cpp
@@ -34,8 +34,10 @@ void insCallBack(const novatel_gps_msgs::InspvaConstPtr& ins) {
   double northing, easting, z;
   std::string zone;
   LLtoUTM(ins->latitude, ins->longitude, northing, easting, zone);
-  if (ignore_z) z = 0.0;
-  else z = ins->height;
+  if (ignore_z)
+    z = 0.0;
+  else
+    z = ins->height;
 
   Eigen::Vector3d position(easting, northing, z);
   Eigen::Matrix3d rot_mat = world_to_local_frame.second.toRotationMatrix();
@@ -119,19 +121,21 @@ int main (int argc, char **argv) {
   priv_node.param<bool>("publish_odom_tf", publish_odom_tf, false);
   priv_node.param<bool>("ignore_z", ignore_z, false);
 
-  // more than parameters, a service call would be better
+  // TODO more than parameters, a service call would be better
   // so that we could change the origin at runtime
   geometry_msgs::PoseStamped origin;
   priv_node.param<bool>("use_fixed_origin", use_fixed_origin, false);
   priv_node.param<double>("origin_x", origin.pose.position.x, 0);
   priv_node.param<double>("origin_y", origin.pose.position.y, 0);
   priv_node.param<double>("origin_z", origin.pose.position.z, 0);
-  // using euler angles might be easier
+  // TODO using euler angles might be easier
   priv_node.param<double>("origin_ox", origin.pose.orientation.x, 0);
   priv_node.param<double>("origin_oy", origin.pose.orientation.y, 0);
   priv_node.param<double>("origin_oz", origin.pose.orientation.z, 0);
   priv_node.param<double>("origin_ow", origin.pose.orientation.w, 1);
 
+  // if use_fixed_origin is false, wait for a /inspva message
+  // and use it as the origin
   if (!use_fixed_origin) {
     auto ins = ros::topic::waitForMessage<novatel_gps_msgs::Inspva>("/inspva", node);
     double northing, easting;


### PR DESCRIPTION
- add parameters to specify a fixed origin more than using the first /inspva message to define it.
- add parameter to ignore elevation.
- remove world->world_child TF link: this link was not used so far and publishing the defined origin is more flexible.
- remove support for /fix topic. The method was outdated and is not useful for us as we always rely on /inspva.
- add eigen3 dependency definition in package.xml as suggested in
  [https://answers.ros.org/question/247968/build_depend-for-eigen3-kinetic-in-packagexml/]()
  Eigen is used for the conversion between world and local frame defined by the specified origin.